### PR TITLE
use %javascript_tokenenchant_token% instead of %tokenenchant_token_nu…

### DIFF
--- a/gui_menus/store.yml
+++ b/gui_menus/store.yml
@@ -72,7 +72,7 @@ items:
       requirements:
         anything_here:
           type: '>='
-          input: '%tokenenchant_tokens_num%'
+          input: '%javascript_tokenenchant_tokens%'
           output: '100'
           deny_commands:
           - '[message] &4Shop &8> &fYou need &c100 Tokens &fto buy &c1 x Granite&f.'


### PR DESCRIPTION
…m% in order to support a number without comma(s).